### PR TITLE
Fixed to match redux-observable 0.13.0

### DIFF
--- a/src/epic-decorator.ts
+++ b/src/epic-decorator.ts
@@ -32,7 +32,7 @@ export function createEpics<T, S>(...instances: any[]): EpicMiddleware<T, S> {
       .map(({propertyName}) => instance[propertyName]));
 
   const epics = [].concat(...epicsMetaData);
-  const rootEpic = combineEpics<T>(...epics);
-  return createEpicMiddleware<T>(rootEpic);
+  const rootEpic = combineEpics<T, S>(...epics);
+  return createEpicMiddleware<T, S>(rootEpic);
 
 }

--- a/src/epic-decorator.ts
+++ b/src/epic-decorator.ts
@@ -26,7 +26,7 @@ export function getEpicsMetadata(instance: any): EpicMetadata[] {
 
 }
 
-export function createEpics<T>(...instances: any[]): EpicMiddleware<T> {
+export function createEpics<T, S>(...instances: any[]): EpicMiddleware<T, S> {
   const epicsMetaData = instances
     .map(instance => getEpicsMetadata(instance)
       .map(({propertyName}) => instance[propertyName]));


### PR DESCRIPTION
Interface of EpicMiddleware changed from `EpicMiddleware<T>` to `EpicMiddleware<T, S>`