### PR TITLE
Update redux-observable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/angular-redux/redux-observable-decorator#readme",
   "peerDependencies": {
     "redux": "3.*",
-    "redux-observable": "^0.10.0 || ^0.11.0 || ^0.12.0"
+    "redux-observable": " ^0.13.0"
   },
   "devDependencies": {
     "@angular/common": "^2.4.0",
@@ -51,7 +51,7 @@
     "karma-typescript-preprocessor": "^0.3.1",
     "karma-webpack": "^2.0.2",
     "redux": "^3.6.0",
-    "redux-observable": "^0.12.2",
+    "redux-observable": "^0.13.0",
     "reflect-metadata": "^0.1.8",
     "rimraf": "^2.5.4",
     "rxjs": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,9 +2406,9 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-observable@^0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.12.2.tgz#4bc1657c7eedace577e114b74ffe6f6fb2b36ccf"
+redux-observable@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.13.0.tgz#35b26c2cdbb71e499b31ca9961da0581c2973909"
 
 redux@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
* redux-observable 0.13 added a second generic argument to the Epic interface,
  PR#5 addressed this issue, updating package dependencies to prevent errors