### PR TITLE
Support redux-observable 0.14.0+

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,26 @@
 # Change Log
 
+# 1.1.0
+
+* Update dependencies to work with redux-observable 0.14.*
+* Add ability to pass redux-observable Options into create epics
+
+*note* If using the `dependencies` feature of redux-observable-options, you will need to use redux-observable 0.14.0 or greater.
+
+
+# Passing in dependencies
+
+```ts
+class TestOne {
+      @Epic() a = (action$, store, deps) => action$
+        .ofType('TEST_A_IN')
+        .mapTo({ type: 'TEST_A_OUT', payload: deps.foo() });
+}
+  
+const epicMiddleware = createEpics(epicOne, { dependencies: {
+  foo: function() { return 'bar'; }
+}});  
+```
 # 1.0.0
 
 ## Breaking Change 

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   "homepage": "https://github.com/angular-redux/redux-observable-decorator#readme",
   "peerDependencies": {
     "redux": "3.*",
-    "redux-observable": " ^0.13.0"
+    "redux-observable": "^0.13.0 || ^0.14.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.4.0",
-    "@angular/compiler": "^2.4.0",
-    "@angular/compiler-cli": "^2.4.0",
-    "@angular/core": "^2.4.0",
-    "@angular/platform-browser": "^2.4.0",
-    "@angular/platform-browser-dynamic": "^2.4.0",
-    "@angular/platform-server": "^2.4.0",
+    "@angular/common": "4.0.0",
+    "@angular/compiler": "4.0.0",
+    "@angular/compiler-cli": "4.0.0",
+    "@angular/core": "4.0.0",
+    "@angular/platform-browser": "4.0.0",
+    "@angular/platform-browser-dynamic": "4.0.0",
+    "@angular/platform-server": "4.0.0",
     "@types/jasmine": "^2.5.38",
     "@types/node": "^6.0.52",
     "awesome-typescript-loader": "^3.0.0-beta.17",
@@ -51,16 +51,16 @@
     "karma-typescript-preprocessor": "^0.3.1",
     "karma-webpack": "^2.0.2",
     "redux": "^3.6.0",
-    "redux-observable": "^0.13.0",
+    "redux-observable": "^0.14.0",
     "reflect-metadata": "^0.1.8",
     "rimraf": "^2.5.4",
     "rxjs": "^5.0.1",
     "ts-loader": "^1.3.3",
     "tslint": "^4.1.1",
     "tslint-loader": "^3.3.0",
-    "typescript": "latest",
+    "typescript": "~2.2.0",
     "uglifyjs": "^2.4.10",
     "webpack": "^2.2.1",
-    "zone.js": "^0.7.4"
+    "zone.js": "^0.8.4"
   }
 }

--- a/src/epic-decorator.ts
+++ b/src/epic-decorator.ts
@@ -26,13 +26,29 @@ export function getEpicsMetadata(instance: any): EpicMetadata[] {
 
 }
 
-export function createEpics<T, S>(...instances: any[]): EpicMiddleware<T, S> {
+function isOptions(...instanceOrOptions) {
+
+  let option = instanceOrOptions[instanceOrOptions.length - 1];
+  let keys = option ? Object.keys(option) : [];
+  return keys.indexOf('dependencies') >= 0 || keys.indexOf('adapter') >= 0;
+
+
+}
+export function createEpics<T, S>(epic, ...epicsOrOptions): EpicMiddleware<T, S> {
+  let instances;
+  let options;
+  if (isOptions(...epicsOrOptions)) {
+    options = epicsOrOptions.slice(epicsOrOptions.length - 1, epicsOrOptions.length)[0];
+
+  }
+  instances = [epic, ...epicsOrOptions];
+
   const epicsMetaData = instances
     .map(instance => getEpicsMetadata(instance)
-      .map(({propertyName}) => instance[propertyName]));
+      .map(({ propertyName }) => instance[propertyName]));
 
   const epics = [].concat(...epicsMetaData);
   const rootEpic = combineEpics<T, S>(...epics);
-  return createEpicMiddleware<T, S>(rootEpic);
+  return createEpicMiddleware<T, S>(rootEpic, options);
 
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,51 +2,52 @@
 # yarn lockfile v1
 
 
-"@angular/common@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-2.4.5.tgz#ada1a22b7ba01d1fdeb300115584478e031e9a4f"
+"@angular/common@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.0.tgz#ca18983222fdab4ecaa7a8b99eda6ff661e6dc92"
 
-"@angular/compiler-cli@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-2.4.5.tgz#efabbe10558b233dcdfe985af2bd2e84f1414c97"
+"@angular/compiler-cli@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.0.0.tgz#35b2d40cd35135aecec4be659532148f5ac67da6"
   dependencies:
-    "@angular/tsc-wrapped" "0.5.1"
+    "@angular/tsc-wrapped" "4.0.0"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
 
-"@angular/compiler@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-2.4.5.tgz#521da325e2e002398e8f9de52cfb03d303729e72"
+"@angular/compiler@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.0.0.tgz#e1aa061a6f8ef269f9748af1a7bc290f9d37ed6c"
 
-"@angular/core@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-2.4.5.tgz#8b05156398afde9636e65527ffb61fc74236af5a"
+"@angular/core@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.0.0.tgz#fd877e074b29dfa9c63b96a21995fc7556d423a3"
 
-"@angular/platform-browser-dynamic@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-2.4.5.tgz#36fa975a8ee2dfe3f60bab561143974e6bdb1eff"
+"@angular/platform-browser-dynamic@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.0.0.tgz#d1d9de80fe1e02735be89f512e0faf5a80d57fa5"
 
-"@angular/platform-browser@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-2.4.5.tgz#fa1bc891b1309bca83845787b9a08db36a787fee"
+"@angular/platform-browser@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.0.0.tgz#512ae9ab19ccc25fa79027f44e291bcee236cd2b"
 
-"@angular/platform-server@^2.4.0":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-2.4.5.tgz#4322d6a3609603edf34101f286d47db8762a08bc"
+"@angular/platform-server@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-4.0.0.tgz#d76d61787cd3be3ce8ed46043d6a8c82572f567d"
   dependencies:
-    parse5 "^2.2.1"
+    parse5 "^3.0.1"
+    xhr2 "^0.1.4"
 
-"@angular/tsc-wrapped@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-0.5.1.tgz#7a69bec999eef41903dddaaccdc862cfcface52c"
+"@angular/tsc-wrapped@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.0.0.tgz#ea91eeda98029cdb0a4ac37d5e25d9d12a4333c1"
   dependencies:
-    tsickle "^0.2"
+    tsickle "^0.21.0"
 
 "@types/jasmine@^2.5.38":
   version "2.5.41"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.41.tgz#d5e86161a0af80d52062b310a33ed65b051a0713"
 
-"@types/node@^6.0.52":
+"@types/node@^6.0.46", "@types/node@^6.0.52":
   version "6.0.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.62.tgz#85222c077b54f25b57417bb708b9f877bda37f89"
 
@@ -2173,9 +2174,11 @@ parse-json@^2.1.0, parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
+parse5@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  dependencies:
+    "@types/node" "^6.0.46"
 
 parsejson@0.0.3:
   version "0.0.3"
@@ -2406,9 +2409,9 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux-observable@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.13.0.tgz#35b26c2cdbb71e499b31ca9961da0581c2973909"
+redux-observable@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.14.1.tgz#9f3d870c69388fdc427ded6770a3e326f3b69693"
 
 redux@^3.6.0:
   version "3.6.0"
@@ -2850,9 +2853,9 @@ ts-loader@^1.3.3:
     object-assign "^4.1.0"
     semver "^5.0.1"
 
-tsickle@^0.2:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.2.5.tgz#60d8e12462e6f8fbdac92d5f5fead2bf49085d82"
+tsickle@^0.21.0:
+  version "0.21.6"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.21.6.tgz#53b01b979c5c13fdb13afb3fb958177e5991588d"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -2906,9 +2909,9 @@ type-is@~1.6.14:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-typescript@^2.1.4, typescript@latest:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.5.tgz#6fe9479e00e01855247cea216e7561bafcdbcd4a"
+typescript@^2.1.4, typescript@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
 uglify-js@^2.6, uglify-js@^2.7.5:
   version "2.7.5"
@@ -3148,6 +3151,10 @@ xdg-basedir@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
+xhr2@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
+
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
@@ -3201,6 +3208,6 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-zone.js@^0.7.4:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"
+zone.js@^0.8.4:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.5.tgz#7906e017482cbff4c3f079c5c34305ce941f5ba2"


### PR DESCRIPTION
* Update dependencies to work with redux-observable 0.14.*
* Add ability to pass redux-observable Options into create epics

*note* If using the `dependencies` feature of redux-observable-options, you will need to use redux-observable 0.14.0 or greater.


# Passing in dependencies

```ts
class TestOne {
      @Epic() a = (action$, store, deps) => action$
        .ofType('TEST_A_IN')
        .mapTo({ type: 'TEST_A_OUT', payload: deps.foo() });
}
  
const epicMiddleware = createEpics(epicOne, { dependencies: {
  foo: function() { return 'bar'; }
}});  
```