### PR TITLE
Don't exclude spec folder in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
     "moduleResolution": "node",
     "declaration": true,
     "module": "commonjs",
-    "lib": ["es5", "dom", "es2015"],
+    "lib": [
+      "es5",
+      "dom",
+      "es2015"
+    ],
     "types": [
       "jasmine",
       "node"
@@ -19,13 +23,14 @@
     "baseUrl": ".",
     "rootDir": ".",
     "paths": {
-      "@redux-observable-decorator": ["./"]
+      "@redux-observable-decorator": [
+        "./"
+      ]
     }
   },
   "exclude": [
     "node_modules",
     "release",
-    "spec",
     "tests.bundle.ts"
   ],
   "angularCompilerOptions": {


### PR DESCRIPTION
Would get TypeScript errors in editor due to decorators being used.